### PR TITLE
feat: add country column to AI regulation news table

### DIFF
--- a/src/render.py
+++ b/src/render.py
@@ -96,8 +96,8 @@ def render_markdown(
     lines.append("## 📰 AI Regulation News")
     if regulations:
         debug_log("'News' is printed.")            
-        lines.append("| No. | 기사일자⬇️ | 제목 | 조건 (주요 키워드) | 주요 내용 | 규제 강도 점수 |")
-        lines.append(_md_sep(6))
+        lines.append("| No. | 기사일자⬇️ | 국가 | 제목 | 조건 (주요 키워드) | 주요 내용 | 규제 강도 점수 |")
+        lines.append(_md_sep(7))
 
         # 기사일자 기준으로 정렬 (날짜 내림차순, 동일 날짜 시 강도 내림차순)
         scored_regulations = []
@@ -115,6 +115,7 @@ def render_markdown(
             lines.append(
                 f"| {idx} | "
                 f"{_esc(s.update_or_filed_date)} | "
+                f"{_esc(s.country)} | "
                 f"{title_cell} | "
                 f"{_esc(s.matched_keywords)} | "
                 f"{_short(s.reason)} | "


### PR DESCRIPTION
이 PR은 AI 규제 뉴스 테이블에 '국가' 필드를 추가하여 각국의 규제 동향을 더 쉽게 파악할 수 있도록 합니다.

주요 변경 사항:
- src/extract.py 뉴스 본문과 제목에서 국가 정보를 자동으로 추출하는 extract_country  함수를 구현했습니다.
- RegulationInfo  데이터 클래스에  country  필드를 추가하고, 뉴스 수집 및 병합 시 해당 정보가 유지되도록 로직을 업데이트했습니다.
- src/render.py "AI Regulation News" 테이블의 헤더에 '국가' 컬럼을 '제목' 왼쪽에 추가했습니다. 테이블 레이아웃을 7개 컬럼에 맞춰 조정하고, 각 행 출력 시 추출된 국가 정보가 포함되도록 수정했습니다.