### PR TITLE
feat: improve slack output with dedup summary and icons

### DIFF
--- a/src/dedup.py
+++ b/src/dedup.py
@@ -53,12 +53,12 @@ def extract_article_url(cell: str) -> str | None:
         return m.group(1).split("&hl=")[0]
     return None
 
-def apply_deduplication(md: str, comments: List[dict]) -> str:
+def apply_deduplication(md: str, comments: List[dict]) -> Tuple[str, dict | None]:
     """
     이전 GitHub 댓글들을 분석하여 중복된 데이터를 'skip' 처리하고 요약을 추가합니다.
     """
     if not comments:
-        return md
+        return md, None
 
     # 1) Base Snapshot Key Set 생성 (모든 이전 댓글 대상)
     base_article_set: Set[str] = set()
@@ -115,8 +115,8 @@ def apply_deduplication(md: str, comments: List[dict]) -> str:
 
 
     # 4) 중복 제거 요약 생성
-    base_news = len(base_article_set)
-    dup_news = total_article_count - new_article_count
+    base_news_count = len(base_article_set)
+    dup_news_count = total_article_count - new_article_count
 
     new_label = f"{new_article_count} (New)"
     if new_article_count > 0:
@@ -125,9 +125,15 @@ def apply_deduplication(md: str, comments: List[dict]) -> str:
     summary_header = (
         "### 중복 제거 요약:\n"
         "🔁 Dedup Summary\n"
-        f"└ News {base_news} (Baseline): "
-        f"{dup_news} (Dup), "
+        f"└ News {base_news_count} (Baseline): "
+        f"{dup_news_count} (Dup), "
         f"{new_label}\n\n"
     )
 
-    return summary_header + current_md
+    stats = {
+        "base_news": base_news_count,
+        "dup_news": dup_news_count,
+        "new_news": new_article_count,
+    }
+
+    return summary_header + current_md, stats

--- a/src/run.py
+++ b/src/run.py
@@ -64,7 +64,7 @@ def main() -> None:
     # Baseline 비교 로직 (Modularized)
     # =========================================================
     comments = list_comments(owner, repo, gh_token, issue_no)
-    md = apply_deduplication(md, comments)
+    md, dedup_stats = apply_deduplication(md, comments)
 
     # 4.1) 실행 시각을 맨 위로 (중복 제거 요약보다 위로)
     md = f"### 실행 시각(KST): {run_ts_kst}\n\n" + md
@@ -87,17 +87,28 @@ def main() -> None:
     # ============================================
 
     slack_lines = []
-    slack_lines.append("📊 AI 규제/정책 모니터링")
-    slack_lines.append(f"🕒 {timestamp}")
+    slack_lines.append(":막대_차트: AI 규제/정책 모니터링")
+    slack_lines.append(f":시계_3시: {timestamp}")
     slack_lines.append("")
 
-    # 📈 Collection Status
-    slack_lines.append("📈 Collection Status")
+    # 중복 제거 요약 (있을 경우만)
+    if dedup_stats:
+        new_news = dedup_stats["new_news"]
+        new_label = f"{new_news} (New)"
+        if new_news > 0:
+            new_label = f"🔴 *{new_label}*"
+        
+        slack_lines.append(":반복: Dedup Summary")
+        slack_lines.append(f"└ News {dedup_stats['base_news']} (Baseline): {dedup_stats['dup_news']} (Dup), {new_label}")
+        slack_lines.append("")
+
+    # :상승세인_차트: Collection Status
+    slack_lines.append(":상승세인_차트: Collection Status")
     slack_lines.append(f"└ News: {len(regulations)}")
     slack_lines.append("")
 
-    # 🔗 GitHub
-    slack_lines.append(f"🔗 GitHub: <{issue_url}|#{issue_no}>")
+    # :링크: GitHub
+    slack_lines.append(f":링크: GitHub: <{issue_url}|#{issue_no}>")
     try:
         post_to_slack(slack_webhook, "\n".join(slack_lines))
         debug_log(f"Slack 전송 완료")


### PR DESCRIPTION
Slack 출력 형식 개선:
상단에 :막대_차트:, :시계_3시: 아이콘 추가
중복 제거 요약(Dedup Summary) 섹션을 추가하여 Baseline 대비 중복/신규 건수 표시
신규 뉴스 발생 시 🔴 *n (New)* 강조 스타일 적용
데이터 로직 업데이트:

src/dedup.py
: 

apply_deduplication
 함수가 중복 제거 통계 데이터를 함께 반환하도록 수정

src/run.py
: 수집된 통계를 바탕으로 Slack 메시지를 생성하도록 로직 보완
[안내] 현재 터미널 환경에서 GitHub 인증(gh auth login) 또는 API 토큰(GITHUB_TOKEN) 설정이 되어 있지 않아 자동 PR 생성이 제한되었습니다.